### PR TITLE
Adds the call to the project structure building subroutine.

### DIFF
--- a/lib/mix/tasks/compile/cmake.ex
+++ b/lib/mix/tasks/compile/cmake.ex
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Compile.Cmake do
     :ok = File.mkdir_p(@default_working_dir)
     cmd("cmake", [@default_cmakelists_path])
     cmd("make", [@default_make_target])
+    Mix.Project.build_structure()
     :ok
   end
 


### PR DESCRIPTION
This fixes an issues I have been seeing in deploying after building artifacts with this library.

This ensures the various build artifacts are located appropriately for release building.

For another project that uses the same approach, please refer to https://hex.pm/packages/elixir_make.