### PR TITLE
Mix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,23 @@ end
 
 ### CMakeLists.txt
 
-Create your CMakeLists.txt in the root of your project.  The source files can reside anywhere
-the CMakeLists.txt file has access to.  Direct the binary output to `priv/`.  A project named
-`EXAMPLE`, with source files in `src/`:
+Create your CMakeLists.txt in the root of your project or specify the path to an
+existing CMakeLists.txt file in your project config.
+
+  def project do
+    [
+      #...
+      cmake_lists: "path/to/CMakeLists.txt"
+    ]
+  end
+
+The source files can reside anywhere the CMakeLists.txt file has access to.
+
+You will need to copy the contents to your `priv` directory by either specifying
+a compile alias or by directing the binary output to `priv/` in your CMakeLists.txt.
+file.
+
+In this example we specify a project named`EXAMPLE`, with source files in `src/`:
 
 ```cmake
 cmake_minimum_required(VERSION 3.0)

--- a/lib/mix/tasks/compile/cmake.ex
+++ b/lib/mix/tasks/compile/cmake.ex
@@ -1,8 +1,6 @@
 defmodule Mix.Tasks.Compile.Cmake do
   @moduledoc "Builds native source using CMake"
   use Mix.Task
-
-  @default_cmakelists_path ".."
   @default_make_target "all"
   @default_working_dir "cmake"
 
@@ -14,7 +12,15 @@ defmodule Mix.Tasks.Compile.Cmake do
 
     working_dir = working_dir(config)
     :ok = File.mkdir_p(working_dir)
-    cmd("cmake", [cmake_list], working_dir)
+
+    make_targets =
+      (config[:make_targets] || [@default_make_target])
+
+    cmake_lists =
+      (config[:cmake_lists] || File.cwd!() )
+      |> Path.expand()
+
+    cmd("cmake", [cmake_lists], working_dir)
     cmd("make", make_targets, working_dir)
     Mix.Project.build_structure()
     :ok

--- a/test/compile_cmake_test.exs
+++ b/test/compile_cmake_test.exs
@@ -9,7 +9,6 @@ defmodule Mix.Tasks.Compile.CmakeTest do
   setup do
     in_fixture(fn ->
       File.rm_rf!("_build")
-      File.rm_rf!("_cmake")
       File.rm_rf!("CMakeLists.txt")
     end)
 


### PR DESCRIPTION
Allow the path to CMakeLists.txt to be passed in through `Mix.Project.config()`. This allows projects to pass their own existing CMakeLists.txt file. If this is passed, it is up to to the implementer to copy the build products to the appropriate location.

Depends on https://github.com/code-lever/elixir-cmake/pull/3